### PR TITLE
Replace FlyCI runners with GitHub runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           - shanyouli
         os:
           - ubuntu-latest
-          - flyci-macos-large-latest-m1
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repository

--- a/.github/workflows/devpkgs.yml
+++ b/.github/workflows/devpkgs.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - flyci-macos-large-latest-m1
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This PR replaces the use of FlyCI macOS runners with GitHub ones since FlyCI macOS runners will be discontinued effective Sep 30, 2024. 

[Read more about the discontinuation of the FlyCI macOS runners](https://flyci.net/blog/flyci-discontinue-macos-runners?utm_source=site_link&utm_medium=github&utm_campaign=discontinue-runners).